### PR TITLE
[c2]: extra newline inserted when posting a reply in IE11 [finish #66099032] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -3387,8 +3387,10 @@ Base = Base.extend({
 wysihtml5.browser = (function() {
   var userAgent   = navigator.userAgent,
       testElement = document.createElement("div"),
-      // Browser sniffing is unfortunately needed since some behaviors are impossible to feature detect
-      isIE        = userAgent.indexOf("MSIE")         !== -1 && userAgent.indexOf("Opera") === -1,
+
+  // Browser sniffing is unfortunately needed since some behaviors are impossible to feature detect
+  var isIE11      = userAgent.indexOf("Trident") !== -1 && userAgent.indexOf(".NET") !== -1,
+      isIE        = isIE11 || (userAgent.indexOf("MSIE") !== -1 && userAgent.indexOf("Opera") === -1),
       isGecko     = userAgent.indexOf("Gecko")        !== -1 && userAgent.indexOf("KHTML") === -1,
       isWebKit    = userAgent.indexOf("AppleWebKit/") !== -1,
       isChrome    = userAgent.indexOf("Chrome/")      !== -1,


### PR DESCRIPTION
1. Use IE11 (don't know about other IE versions -- this didn't happen in Chrome)
2. Go to a topic detail page
3. Click in the reply box
4. Type a character
5. Notice that an extra newline has been inserted before your character. https://www.pivotaltracker.com/story/show/66099032
