### PR TITLE
[c2]: Unable select PRE in IE [finish #67054360] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -3626,7 +3626,7 @@ wysihtml5.browser = (function() {
      * All browsers except Safari and Chrome automatically scroll the range/caret position into view
      */
     autoScrollsToCaret: function() {
-      return !isWebKit;
+      return !isWebKit && !isIE11;
     },
 
     /**


### PR DESCRIPTION
I was testing in IE11
Exists in Production

Case 1
1. Create a new reply
2. Try to select PRE in WYSIWYG editor
Observe you are unable to select it.

Case 2
1. Create a new reply
2. click on OL or UL
3. enter some text
4. press enter
5. add some text 
6. Select PRE
observe the text where your cursor is at is not switched to PRE text

I was testing on IE10 and not all the icons are showing up and in Ie9 where I can't repro. Ie and Wysiwig need help! I will have to come back to test some more when I have more time https://www.pivotaltracker.com/story/show/67054360
