### PR TITLE
[c2]: Drag and drop causes page to jump to a different location in Chrome and Safari [finish #72944462] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -9046,7 +9046,7 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
       dom.addClass(this.link, CLASS_NAME_OPENED);
       this.container.style.display = "";
       this.fire("show");
-      if (firstField && !elementToChange) {
+      if (firstField && firstField.name != 'image' && !elementToChange) {
         try {
           firstField.focus();
         } catch(e) {}

--- a/src/toolbar/dialog.js
+++ b/src/toolbar/dialog.js
@@ -178,7 +178,7 @@
       dom.addClass(this.link, CLASS_NAME_OPENED);
       this.container.style.display = "";
       this.fire("show");
-      if (firstField && !elementToChange) {
+      if (firstField && firstField.name != 'image' && !elementToChange) {
         try {
           firstField.focus();
         } catch(e) {}


### PR DESCRIPTION
1. have a page with several replies and comments (Was able to repro on chrome and safari)
2. scroll down 
3. Click on comment
4. Click on the image logo within wysiwyg

Actual: the page jumps to a different location on the page
Expected: the page should stay where it is in the browser and the image Drag and Drop should display https://www.pivotaltracker.com/story/show/72944462
