### PR TITLE
[c2]: Value attribute should be supported by WYSIWYG editor [finish #74273870] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -5144,7 +5144,7 @@ wysihtml5.dom.parse = (function() {
       var REG_EXP = /[^ a-z0-9_\-]/gi;
       return function(attributeValue) {
         if (!attributeValue) {
-          return "";
+          return null;
         }
         return attributeValue.replace(REG_EXP, "");
       };


### PR DESCRIPTION
A user reported that the "value" attribute is being stripped out by the WYSIWYG editor.  We state that this is supported HTML on the "Supported HTML" page.

For example:

```
<ol>
<li value="100">100</li>
<li>101</li>
</ol>
```

Should be valid HTML that the WYSIWYG respects.

https://console.getsatisfaction.com/getsatisfaction/conversations/extending_supported_html_tags_and_parameters
 https://www.pivotaltracker.com/story/show/74273870
