### PR TITLE
[c2]: Image upload prepends images to replies in IE11 [finish #75544978] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -3704,7 +3704,7 @@ wysihtml5.browser = (function() {
      * In IE it's impssible for the user and for the selection library to set the caret after an <img> when it's the lastChild in the document
      */
     hasProblemsSettingCaretAfterImg: function() {
-      return isIE;
+      return isIE && !isIE11;
     },
 
     hasUndoInContextMenu: function() {


### PR DESCRIPTION
Originally reported [here](https://getsatisfaction.com/getsatisfaction/topics/new_interface_issue_with_uploading_photos_while_using_ie_11). Steps to reproduce:
- Type a few words into a reply in IE11
- Insert an image using the file selection option (not drag and drop)

Expected result:
- The image is inserted at the cursor's position

Actual result:
- The image is inserted at the beginning of the reply
  https://www.pivotaltracker.com/story/show/75544978
