### PR TITLE
[c2]: Add support for HTML5 video tag [finish #87646802] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -5141,7 +5141,7 @@ wysihtml5.dom.parse = (function() {
     })(),
 
     alt: (function() {
-      var REG_EXP = /[^ a-z0-9_\-]/gi;
+      var REG_EXP = /[^ a-z0-9_\-\/]/gi;
       return function(attributeValue) {
         if (!attributeValue) {
           return null;

--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -4813,20 +4813,35 @@ wysihtml5.dom.parse = (function() {
         isString      = typeof(elementOrHtml) === "string",
         element,
         newNode,
-        firstChild;
+        firstChild,
+        beginningChild,
+        endingChild;
 
     if (isString) {
-      element = wysihtml5.dom.getAsDom(elementOrHtml, context);
+      element = wysihtml5.dom.getAsDom(elementOrHtml.trim(), context);
     } else {
       element = elementOrHtml;
     }
+
+    beginningChild = element.firstChild;
+    endingChild = element.lastChild;
 
     while (element.firstChild) {
       firstChild = element.firstChild;
       newNode = _convert(firstChild, cleanUp);
       element.removeChild(firstChild);
       if (newNode) {
+        // insert an invisible space before the video tag when it's at the beginning of the textarea to fix cursor problems
+        if (newNode.nodeName === 'VIDEO' && beginningChild.outerHTML === firstChild.outerHTML) {
+          fragment.appendChild(newNode.ownerDocument.createTextNode(wysihtml5.INVISIBLE_SPACE));
+        }
+
         fragment.appendChild(newNode);
+
+        // insert an invisible space after the video tag when it's at the end of the textarea to fix cursor problems
+        if (newNode.nodeName === 'VIDEO' && endingChild.outerHTML === firstChild.outerHTML) {
+          fragment.appendChild(newNode.ownerDocument.createTextNode(wysihtml5.INVISIBLE_SPACE));
+        }
       }
     }
 
@@ -8599,11 +8614,11 @@ wysihtml5.views.View = Base.extend(
       setTimeout(function() { that.parent.fire("newword:composer"); }, 0);
     });
 
-    // --------- Make sure that images are selected when clicking on them ---------
+    // --------- Make sure that images and videos are selected when clicking on them ---------
     if (!browser.canSelectImagesInContentEditable()) {
       dom.observe(element, "mousedown", function(event) {
         var target = event.target;
-        if (target.nodeName === "IMG") {
+        if (target.nodeName === "IMG" || target.nodeName === "VIDEO") {
           that.selection.selectNode(target);
           event.preventDefault();
         }


### PR DESCRIPTION
As an end-user, I should be able to embed an HTML5 video in my conversations, replies, or any other UGC area of the community.  Some customers host their own videos in places like the AWS or their own website.

**Validation:**
We should ensure that the video src is HTTPS.

The width should be 100%.  But we should set a max-width of XXX px (need to determine what we do for other embeds).

**Reference:**
http://www.w3schools.com/html/html5_video.asp

**Acceptance Criteria:**
- post a new reply or conversation
- edit HTML view
- embed a video tag that references a secure URL
- view the reply
- observe that the video is embedded and is responsive to layout/screen size changes

**Acceptance Criteria: negative case**
- post a new reply or conversation
- embed a video tag that references a non-secure URL
- view the reply
- observe that the video is not embedded
 https://www.pivotaltracker.com/story/show/87646802

