### PR TITLE
[c2]: Wysiwyg moving cursor above newline [finish #82686978] 

### DIFF
--- a/dist/wysihtml5-0.4.1pre.js
+++ b/dist/wysihtml5-0.4.1pre.js
@@ -3456,6 +3456,10 @@ wysihtml5.browser = (function() {
       return isIE;
     },
 
+    isChrome: function () {
+      return isChrome;
+    },
+
     /**
      * IE6+7 throw a mixed content warning when the src of an iframe
      * is empty/unset or about:blank
@@ -8605,7 +8609,7 @@ wysihtml5.views.View = Base.extend(
     // --------- newword event ---------
     dom.observe(element, "keyup", function(event) {
       var keyCode = event.keyCode;
-      if (keyCode === wysihtml5.SPACE_KEY || (!isChrome && keyCode === wysihtml5.ENTER_KEY)) {
+      if (keyCode === wysihtml5.SPACE_KEY || (!wysihtml5.browser.isChrome() && keyCode === wysihtml5.ENTER_KEY)) {
         that.parent.fire("newword:composer");
       }
     });


### PR DESCRIPTION
Originally reported by AK [here](https://getsatisfaction.com/the_satisfactory/topics/post-box-moves-cursor-when-pasting-links-into-post).
Also reported in here: https://getsatisfaction.com/getsatisfaction/topics/manage-workspace-editing-bug-report-cursor-jumps-back-to-previous-line-when-trying-to-start-a-new-paragraph

To reproduce:
- Add a link to the wysiwyg editor in c2. 
- Press enter twice

Expected:
- You get 2 newlines and the cursor appears after the second newline

Actual:
- You get 2 newlines, but the cursor stays above the second newline https://www.pivotaltracker.com/story/show/82686978

